### PR TITLE
ButtonsPadding is too high

### DIFF
--- a/resources/less/forum/ChatModal.less
+++ b/resources/less/forum/ChatModal.less
@@ -82,7 +82,7 @@
         margin: auto;
 
         .ButtonsPadding {
-            height: 350px;
+            height: 35px;
         }
 
         .ButtonSave {


### PR DESCRIPTION
Before:

![](https://i.imgur.com/qFvRztp.png)

After:

![](https://i.imgur.com/VnMxIEv.png)

You could just add `margin-top` to the save button as well, so you don't need the padding element