### PR TITLE
Fix message dropdown being cut when there is only 1 message

### DIFF
--- a/resources/less/forum/ChatViewport.less
+++ b/resources/less/forum/ChatViewport.less
@@ -45,6 +45,7 @@
     .wrapper {
         overflow-y: scroll;
         overflow-x: hidden;
+        height: 100%;
 
         .welcome {
             margin: auto;


### PR DESCRIPTION
This PR fixes the message dropdown being cut when there is just one chat message.

**Before:**

![](https://i.imgur.com/DtIMDrJ.png)

**After:**

![](https://i.imgur.com/LOHYty8.png)